### PR TITLE
fix parallel open with multiple devices

### DIFF
--- a/pyaardvark/cli_tool.py
+++ b/pyaardvark/cli_tool.py
@@ -67,10 +67,8 @@ def spi(a, args):
     print(' '.join('%02x' % ord(c) for c in data))
 
 def scan(a, args):
-    for port in pyaardvark.find_devices():
-        dev = pyaardvark.open(port)
-        print('Device #%d: %s' % (port, dev.unique_id_str()))
-        dev.close()
+    for (port, unique_id) in pyaardvark.find_devices(filter_in_use=False):
+        print('Device #%d: %s' % (port, unique_id))
 
 def main(args=None):
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
If more than one aardvark device is connected and several
tools/instances want to open devices it was observed that the
open function fails with IOError:ERR_UNABLE_TO_OPEN.

This is fixed by using the py_aa_find_devices_ext in find_devices.

The find_devices returns now a list of tuples with (port, unique_id).

Signed-off-by: Heiko Thiery <heiko.thiery@kontron.com>