### PR TITLE
find_devices() now returns a list of dictionaries

### DIFF
--- a/pyaardvark/cli_tool.py
+++ b/pyaardvark/cli_tool.py
@@ -67,8 +67,8 @@ def spi(a, args):
     print(' '.join('%02x' % ord(c) for c in data))
 
 def scan(a, args):
-    for (port, unique_id) in pyaardvark.find_devices(filter_in_use=False):
-        print('Device #%d: %s' % (port, unique_id))
+    for device in pyaardvark.find_devices(filter_in_use=False):
+        print('Device #%d: %s' % (device['port'], device['serial_number']))
 
 def main(args=None):
     parser = argparse.ArgumentParser(


### PR DESCRIPTION
To support more that only port and unique id the return value now is
a dictionary that has port,serial_number and the in_use flag.

Signed-off-by: Heiko Thiery <heiko.thiery@kontron.com>