### PR TITLE
Feature/slave response

### DIFF
--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -535,7 +535,7 @@ class Aardvark(object):
             raise RuntimeError('SPI Mode not supported')
 
     def spi_write(self, data):
-        "Write a stream of bytes to a SPI device."""
+        """Write a stream of bytes to a SPI device."""
         data_out = array.array('B', data)
         data_in = array.array('B', (0,) * len(data_out))
         ret = api.py_aa_spi_write(self.handle, len(data_out), data_out,

--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -487,7 +487,8 @@ class Aardvark(object):
         _raise_error_if_negative(ret)
         self._i2c_slave_response = data
 
-    def i2c_slave_write_stats(self):
+    @property
+    def i2c_slave_last_transmit_size(self):
         """Returns the number of bytes transmitted by the slave."""
         ret = api.py_aa_i2c_slave_write_stats(self.handle)
         _raise_error_if_negative(ret)

--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -473,6 +473,12 @@ class Aardvark(object):
         ret = api.py_aa_i2c_slave_set_response(self.handle, len(data), data)
         _raise_error_if_negative(ret)
 
+    def i2c_slave_write_stats(self):
+        """Returns the number of bytes transmitted by the slave."""
+        ret = api.py_aa_i2c_slave_write_stats(self.handle)
+        _raise_error_if_negative(ret)
+        return ret
+
     def enable_i2c_monitor(self):
         """Activate the I2C monitor.
 

--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2014-2015  Kontron Europe GmbH
+#               2017       CAMCO Produktions- und Vertriebs-GmbH
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -461,6 +462,16 @@ class Aardvark(object):
         _raise_error_if_negative(ret)
         del data[ret:]
         return (slave_addr, data.tostring())
+
+    def i2c_slave_set_response(self, data):
+        """Prepare response to next read command.
+
+        Args:
+            data:       an array of bytes to respond with
+        """
+        data = array.array('B', data)
+        ret = api.py_aa_i2c_slave_set_response(self.handle, len(data), data)
+        _raise_error_if_negative(ret)
 
     def enable_i2c_monitor(self):
         """Activate the I2C monitor.

--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -453,7 +453,7 @@ class Aardvark(object):
     def i2c_slave_read(self):
         """Read the bytes from an I2C slave reception.
 
-        The bytes are returns as an string object.
+        The bytes are returned as a string object.
         """
         data = array.array('B', (0,) * self.BUFFER_SIZE)
         (ret, slave_addr) = api.py_aa_i2c_slave_read(self.handle, self.BUFFER_SIZE,

--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -224,6 +224,9 @@ class Aardvark(object):
 
         _raise_error_if_negative(ret)
 
+        # Initialize shadow variables
+        self._i2c_slave_response = None
+
     def __enter__(self):
         return self
 
@@ -463,15 +466,26 @@ class Aardvark(object):
         del data[ret:]
         return (slave_addr, data.tostring())
 
-    def i2c_slave_set_response(self, data):
-        """Prepare response to next read command.
+    @property
+    def i2c_slave_response(self):
+        """Response to next read command.
 
-        Args:
-            data:       an array of bytes to respond with
+        An array of bytes that will be transmitted to the I2C master with the
+        next read operation.
+
+        Warning: Due to the fact that the Aardvark API does not provide a means
+        to read out this value, it is buffered when setting the property.
+        Reading the property therefore might not return what is actually stored
+        in the device.
         """
+        return self._i2c_slave_response
+
+    @i2c_slave_response.setter
+    def i2c_slave_response(self, data):
         data = array.array('B', data)
         ret = api.py_aa_i2c_slave_set_response(self.handle, len(data), data)
         _raise_error_if_negative(ret)
+        self._i2c_slave_response = data
 
     def i2c_slave_write_stats(self):
         """Returns the number of bytes transmitted by the slave."""

--- a/tests/test_aardvark.py
+++ b/tests/test_aardvark.py
@@ -383,6 +383,19 @@ class TestAardvark(object):
         api.py_aa_i2c_slave_read.return_value = (-1, 0)
         self.a.i2c_slave_read()
 
+    def test_i2c_slave_set_response(self, api):
+        api.py_aa_i2c_slave_set_response.return_value = 0
+        data = range(4)
+        self.a.i2c_slave_response = data
+        api.py_aa_i2c_slave_set_response.assert_called_once_with(
+                self.a.handle, len(data), array.array('B', data))
+
+    @raises(IOError)
+    def test_i2c_slave_set_response_error(self, api):
+        api.py_aa_i2c_slave_set_response.return_value = -1
+        data = range(4)
+        self.a.i2c_slave_response = data
+
     def test_enable_i2c_monitor(self, api):
         api.py_aa_i2c_monitor_enable.return_value = 0
         self.a.enable_i2c_monitor()

--- a/tests/test_aardvark.py
+++ b/tests/test_aardvark.py
@@ -396,6 +396,18 @@ class TestAardvark(object):
         data = range(4)
         self.a.i2c_slave_response = data
 
+    def test_last_transmit_size(self, api):
+        expected_result = 23
+        api.py_aa_i2c_slave_write_stats.return_value = expected_result
+        actual_result = self.a.i2c_slave_last_transmit_size
+        api.py_aa_i2c_slave_write_stats.assert_called_once_with(self.a.handle)
+        eq_(actual_result, expected_result)
+
+    @raises(IOError)
+    def test_last_transmit_size_error(self, api):
+        api.py_aa_i2c_slave_write_stats.return_value = -1
+        self.a.i2c_slave_last_transmit_size
+
     def test_enable_i2c_monitor(self, api):
         api.py_aa_i2c_monitor_enable.return_value = 0
         self.a.enable_i2c_monitor()


### PR DESCRIPTION
Fixes some docstring typos and adds missing bindings for `py_aa_i2c_slave_set_response` and `py_aa_i2c_slave_write_stats`.