### PR TITLE
Add Free Bus command

### DIFF
--- a/pyaardvark/aardvark.py
+++ b/pyaardvark/aardvark.py
@@ -447,6 +447,15 @@ class Aardvark(object):
         self.i2c_master_write(i2c_address, data, I2C_NO_STOP)
         return self.i2c_master_read(i2c_address, length)
 
+    def i2c_free_bus(self):
+        """Free the Aardvark I2C subsystem from a held bus condition.
+
+        Raises ERR_I2C_BUS_ALREADY_FREE if I2C bus was already free.
+        """
+        ret = api.py_aa_i2c_free_bus(self.handle)
+        _raise_error_if_negative(ret)
+        return ret
+    
     def poll(self, timeout=None):
         """Wait for an event to occur.
 


### PR DESCRIPTION
Adds a call to access the Free Bus function of the Aardvark.

I opted to check the status code on return, which will cause an exception to be raised if the bus was already free. Even though it's a non-issue (bus is free on either outcome), the user won't be able to determine that the bus _was_ already free, which could potentially be valuable to the user. For library code, I prefer not to remove choices from users.

Realistically, all usages of the function will likely be:
```python
try:
    dev.i2c_free_bus()
except IOError as e:
    if (e.errno == ERR_I2C_BUS_ALREADY_FREE):
        pass
    else:
        raise e
```