### PR TITLE
Open README.md rather than the unexisting README.rst file in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except (OSError, subprocess.CalledProcessError, IOError) as e:
     except IOError:
         version = 'unknown'
 
-with open('README.rst') as f:
+with open('README.md') as f:
     readme = f.read()
 
 setup(name = name,


### PR DESCRIPTION
This is a trivial change to fix an installation error, when setup.py attempts to open README.rst instead of the existing README.md.